### PR TITLE
Update SciPy Import Statements for 1.13.0 Deprecation and Upgrade Praatio Dependency to Latest Version

### DIFF
--- a/conch/analysis/formants/lpc.py
+++ b/conch/analysis/formants/lpc.py
@@ -4,7 +4,7 @@ import scipy as sp
 from scipy.signal import lfilter
 
 from scipy.fftpack import fft, ifft
-from scipy.signal import gaussian
+from scipy.signal.windows import gaussian
 
 from ..helper import nextpow2
 from ..functions import BaseAnalysisFunction

--- a/conch/analysis/pitch/autocorrelation.py
+++ b/conch/analysis/pitch/autocorrelation.py
@@ -1,6 +1,7 @@
 import librosa
 from numpy import log10, arange, hanning, log, correlate, max, mean, maximum, inf
-from scipy.signal import gaussian, argrelmax
+from scipy.signal.windows import gaussian
+from scipy.signal import argrelmax
 from ..functions import BaseAnalysisFunction
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 pyraat
-praatio ~= 5.0
+praatio
 librosa
 pytest
 sphinx>=1.3b3

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
           install_requires=[
               'numpy',
               'scipy',
-              'praatio ~= 5.0',
+              'praatio',
               'librosa',
               'pyraat'
           ],


### PR DESCRIPTION
**SciPy:**
- As noted in the [SciPy 1.13.0 release notes](https://scipy.github.io/devdocs/release/1.13.0-notes.html#expired-deprecations), window functions can no longer be imported from `scipy.signal`.
- Updated the relevant import statements to reflect this deprecation, replacing `scipy.signal` with the new alternative.

**Praatio:**
- Updated the Praatio dependency from `~=5.0` to the latest version.
- After reviewing the [Praatio upgrade notes](https://github.com/timmahrt/praatIO/blob/main/UPGRADING.md), no code changes were necessary as the update did not affect existing functionality. 